### PR TITLE
Wiki 作成時の Slack への通知

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore dotenv
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ group :development, :test do
   gem 'pry-stack_explorer' # スタックをたどれる
 
 end
+

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'cancancan'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# ENV
+gem 'dotenv-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
@@ -60,4 +63,3 @@ group :development, :test do
   gem 'pry-stack_explorer' # スタックをたどれる
 
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'cancancan'
 # ENV
 gem 'dotenv-rails'
 
+# Slack
+gem 'slack-notifier'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/app/models/concerns/lib.rb
+++ b/app/models/concerns/lib.rb
@@ -1,0 +1,12 @@
+module Notification
+  extend ActiveSupport::Concern
+
+  def slack_notify(text, channel)
+    require 'slack-notifier'
+    notifier = Slack::Notifier.new( ENV["SLACK_INCOMING_URL"],
+                                    username: "Wiki bot",
+                                    icon_url: "https://www.eff.org/files/FPG_icon_Wikileaks.png")
+    notifier.channel = channel
+    notifier.ping text, unfurl_links: true
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,9 @@
 class Document < ActiveRecord::Base
+  require 'lib'
+  include Notification
+
+  after_create :notify_new_document
+
   has_many :document_tags
   has_many :tags, through: :document_tags
   belongs_to :user
@@ -6,4 +11,19 @@ class Document < ActiveRecord::Base
   validates :user_id, presence: true
   validates :title, presence: true
   validates :content, presence: true
+
+  private
+
+  def notify_new_document
+    message = <<"EOS"
+#{user.name} wrote new wiki
+Look at #{url}
+EOS
+    slack_notify(message, '#dev')
+  end
+
+  def url
+    "https://rsl-wiki.l-u-l.tk/#/wiki/#{id}"
+  end
+
 end


### PR DESCRIPTION
## Why
- 作ってもみんな見てくれないとね汗
## What

![https://gyazo.com/04b1bf69398a0034d84fbfccd246a7c8](https://i.gyazo.com/04b1bf69398a0034d84fbfccd246a7c8.png)
## How
- [bkeepers/dotenv](https://github.com/bkeepers/dotenv) を使って `SLACK_INCOMING_URL` を読み込む。
- [stevenosloan/slack-notifier](https://github.com/stevenosloan/slack-notifier) で、 `Document` の `after_create` で Slack に通知。
## TODO
- put `.env` file

sample

```
SLACK_INCOMING_URL="https://hooks.slack.com/services/......"

```
### note

`rails s` でしかちゃんと環境変数読み込めるかチェックしてないす<(_ _)>
